### PR TITLE
Desugar anonymous lambda functions & implement a program printer

### DIFF
--- a/samples/DesugarExample.bl
+++ b/samples/DesugarExample.bl
@@ -3,3 +3,13 @@ let x = ((a, b) => a+b)(12, 13);
 define f(y) as {
     return (() => 54)();
 }
+
+if (true) {
+    let x = (() => 12)();
+}
+
+define nested() as {
+    return ((a) => (() => 15)())(12);
+}
+
+let main = 12;

--- a/samples/DesugarExample.bl
+++ b/samples/DesugarExample.bl
@@ -1,3 +1,10 @@
+{
+    {
+        let a = 12;
+        let b = 13;
+    }
+}
+
 let x = ((a, b) => a+b)(12, 13);
 
 define f(y) as {
@@ -11,5 +18,9 @@ if (true) {
 define nested() as {
     return ((a) => (() => 15)())(12);
 }
+
+let alsoNested = () => {
+    let a = (() => { return (() => 12)(); })();
+};
 
 let main = 12;

--- a/samples/DesugarExample.bl
+++ b/samples/DesugarExample.bl
@@ -1,0 +1,5 @@
+let x = ((a, b) => a+b)(12, 13);
+
+define f(y) as {
+    return (() => 54)();
+}

--- a/samples/FirstExample.bl
+++ b/samples/FirstExample.bl
@@ -1,7 +1,7 @@
 define main() as {
     let x = 13 + 14;
     let y = 13 * (x - f(12));
-    return x - g(y);
+    return x - g(y) * chomp(18);
 }
 
 define f(arg) as {
@@ -9,6 +9,12 @@ define f(arg) as {
     let moreHelpful = ((a, b) => (a+b)-arg)(34, 55);
     return helpful;
 }
+
+let chomp = food =>
+    (a => {
+        let x = 12;
+        return a + x;
+    })(food);
 
 let curry = func => (x => func(x, 2, 3, 4));
 

--- a/src/main/antlr/Brucelang.g4
+++ b/src/main/antlr/Brucelang.g4
@@ -42,7 +42,8 @@ idList
     ;
 
 exprList
-    : expr (',' expr)*
+    :                   # noExprs
+    | expr (',' expr)*  # someExprs
     ;
 
 expr // top-level expression class

--- a/src/main/java/io/rodyamirov/brucelang/Main.java
+++ b/src/main/java/io/rodyamirov/brucelang/Main.java
@@ -5,7 +5,9 @@ import io.rodyamirov.brucelang.ast.ProgramNode;
 import io.rodyamirov.brucelang.lexparse.BrucelangLexer;
 import io.rodyamirov.brucelang.lexparse.BrucelangParser;
 import io.rodyamirov.brucelang.staticanalysis.FunctionDependencyAnalyzer;
+import io.rodyamirov.brucelang.staticanalysis.LambdaDesugarer;
 import io.rodyamirov.brucelang.staticanalysis.NameRegistrar;
+import io.rodyamirov.brucelang.staticanalysis.TreePrinter;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -33,8 +35,10 @@ public class Main {
 
         ASTBuilder builder = new ASTBuilder();
         ProgramNode program = builder.visitProgram(parser.program());
-
+        LambdaDesugarer.removeAnonymousFunctions(program);
         NameRegistrar.registerNames(program);
+        System.out.println(TreePrinter.printTree(program));
+
         program.getNamespace().getVariableDeclaration("main"); // throws Exception if not defined
 
         FunctionDependencyAnalyzer.Path

--- a/src/main/java/io/rodyamirov/brucelang/ast/ASTBuilder.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/ASTBuilder.java
@@ -9,6 +9,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ASTBuilder extends AbstractParseTreeVisitor<Object> implements BrucelangVisitor<Object> {
@@ -92,9 +93,12 @@ public class ASTBuilder extends AbstractParseTreeVisitor<Object> implements Bruc
         }
 
         // this returns null if there isn't one, which is great
-        BlockStatementNode elseStatement = visitBlockStmt(ctx.blockStmt(conditions.size() + 1));
+        BlockStatementNode maybeElse = Optional
+                .ofNullable(ctx.blockStmt(conditions.size() + 1))
+                .map(this::visitBlockStmt)
+                .orElse(null);
 
-        return new IfStatementNode(conditions, resultStatements, elseStatement);
+        return new IfStatementNode(conditions, resultStatements, maybeElse);
     }
 
     /**

--- a/src/main/java/io/rodyamirov/brucelang/ast/BinOpExprNode.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/BinOpExprNode.java
@@ -3,7 +3,7 @@ package io.rodyamirov.brucelang.ast;
 // TODO -- remove this class and replace it with a function call node
 public final class BinOpExprNode extends ExpressionNode {
     private final Operators.BinOp operation;
-    private final ExpressionNode leftChild, rightChild;
+    private ExpressionNode leftChild, rightChild;
 
     public BinOpExprNode(Operators.BinOp operation, ExpressionNode leftChild, ExpressionNode rightChild) {
         this.operation = operation;
@@ -24,7 +24,15 @@ public final class BinOpExprNode extends ExpressionNode {
         return leftChild;
     }
 
+    public void setLeftChild(ExpressionNode leftChild) {
+        this.leftChild = leftChild;
+    }
+
     public ExpressionNode getRightChild() {
         return rightChild;
+    }
+
+    public void setRightChild(ExpressionNode rightChild) {
+        this.rightChild = rightChild;
     }
 }

--- a/src/main/java/io/rodyamirov/brucelang/ast/BlockStatementNode.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/BlockStatementNode.java
@@ -1,18 +1,39 @@
 package io.rodyamirov.brucelang.ast;
 
-import com.google.common.collect.ImmutableList;
+import io.rodyamirov.brucelang.astexceptions.WrongOrderException;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
-public final class BlockStatementNode extends StatementNode {
-    private final ImmutableList<StatementNode> statements;
+public final class BlockStatementNode extends StatementNode implements StatementListHolder {
+    private final List<StatementNode> statements;
+
+    private String localName;
 
     public BlockStatementNode(List<StatementNode> statements) {
-        this.statements = ImmutableList.copyOf(statements);
+        this.statements = statements;
+        this.localName = null; // to be named later
     }
 
-    public ImmutableList<StatementNode> getStatements() {
+    @Nonnull
+    public String getLocalName() {
+        if (localName == null) {
+            throw new WrongOrderException(this, "Name not yet defined for this block!");
+        }
+        return localName;
+    }
+
+    public void setLocalName(@Nonnull String localName) {
+        this.localName = localName;
+    }
+
+    public List<StatementNode> getStatements() {
         return statements;
+    }
+
+    @Override
+    public void insertStatementNode(int index, StatementNode statementNode) {
+        statements.add(index, statementNode);
     }
 
     @Override

--- a/src/main/java/io/rodyamirov/brucelang/ast/BoolExprNode.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/BoolExprNode.java
@@ -12,7 +12,7 @@ public final class BoolExprNode extends ExpressionNode {
         visitor.visitBoolExprNode(this);
     }
 
-    public boolean isValue() {
+    public boolean getValue() {
         return value;
     }
 }

--- a/src/main/java/io/rodyamirov/brucelang/ast/ExpressionNode.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/ExpressionNode.java
@@ -6,8 +6,20 @@ import static io.rodyamirov.brucelang.types.UnknownType.UNKNOWN_TYPE;
  * Just an extension class signaling "this is a thing that can be evaluated"
  */
 public abstract class ExpressionNode extends TypedNode {
+    // whether this expression is a definitional expression (something is "let x = [this expression]")
+    private boolean isDefExpr;
+
     protected ExpressionNode() {
         super(UNKNOWN_TYPE);
+        isDefExpr = false;
+    }
+
+    public boolean isDefExpr() {
+        return isDefExpr;
+    }
+
+    public void setDefExpr(boolean defExpr) {
+        isDefExpr = defExpr;
     }
 
     /**

--- a/src/main/java/io/rodyamirov/brucelang/ast/FunctionCallNode.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/FunctionCallNode.java
@@ -1,16 +1,15 @@
 package io.rodyamirov.brucelang.ast;
 
-import com.google.common.collect.ImmutableList;
-
+import java.util.ArrayList;
 import java.util.List;
 
 public final class FunctionCallNode extends ExpressionNode {
-    private final ExpressionNode functionNode;
-    private final ImmutableList<ExpressionNode> arguments;
+    private ExpressionNode functionNode;
+    private final List<ExpressionNode> arguments;
 
     public FunctionCallNode(ExpressionNode functionNode, List<ExpressionNode> arguments) {
         this.functionNode = functionNode;
-        this.arguments = ImmutableList.copyOf(arguments);
+        this.arguments = new ArrayList<>(arguments);
     }
 
     @Override
@@ -22,7 +21,11 @@ public final class FunctionCallNode extends ExpressionNode {
         return functionNode;
     }
 
-    public ImmutableList<ExpressionNode> getArguments() {
+    public void setFunctionNode(ExpressionNode functionNode) {
+        this.functionNode = functionNode;
+    }
+
+    public List<ExpressionNode> getArguments() {
         return arguments;
     }
 }

--- a/src/main/java/io/rodyamirov/brucelang/ast/FunctionExprNode.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/FunctionExprNode.java
@@ -1,28 +1,27 @@
 package io.rodyamirov.brucelang.ast;
 
-import com.google.common.collect.ImmutableList;
-
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class FunctionExprNode extends ExpressionNode {
+public class FunctionExprNode extends ExpressionNode implements StatementListHolder {
     private static final AtomicInteger canonicalIds = new AtomicInteger(0);
     private final int myId = canonicalIds.getAndIncrement();
 
     private final String selfName;
-    private final ImmutableList<VariableDeclarationNode> parameterNodes;
+    private final List<VariableDeclarationNode> parameterNodes;
     private final List<StatementNode> definitionStatements;
 
     private FunctionExprNode(List<VariableDeclarationNode> parameterNodes, List<StatementNode> definitionStatements) {
         this.selfName = "$lambda$" + myId;
-        this.definitionStatements = definitionStatements;
-        this.parameterNodes = ImmutableList.copyOf(parameterNodes);
+        this.definitionStatements = new ArrayList<>(definitionStatements);
+        this.parameterNodes = new ArrayList<>(parameterNodes);
     }
 
     private FunctionExprNode(String localName, List<VariableDeclarationNode> parameterNodes, List<StatementNode> definitionStatements) {
         this.selfName = localName;
-        this.definitionStatements = definitionStatements;
-        this.parameterNodes = ImmutableList.copyOf(parameterNodes);
+        this.definitionStatements = new ArrayList<>(definitionStatements);
+        this.parameterNodes = new ArrayList<>(parameterNodes);
     }
 
     public static FunctionExprNode makeNamedFunction(String localName,
@@ -41,12 +40,17 @@ public class FunctionExprNode extends ExpressionNode {
         return selfName;
     }
 
-    public ImmutableList<VariableDeclarationNode> getParameterNodes() {
+    public List<VariableDeclarationNode> getParameterNodes() {
         return parameterNodes;
     }
 
     public List<StatementNode> getDefinitionStatements() {
         return definitionStatements;
+    }
+
+    @Override
+    public void insertStatementNode(int index, StatementNode statementNode) {
+        this.definitionStatements.add(index, statementNode);
     }
 
     @Override

--- a/src/main/java/io/rodyamirov/brucelang/ast/IfStatementNode.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/IfStatementNode.java
@@ -1,37 +1,40 @@
 package io.rodyamirov.brucelang.ast;
 
-import com.google.common.collect.ImmutableList;
-
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 
 public final class IfStatementNode extends StatementNode {
-    private final ImmutableList<ExpressionNode> conditions;
-    private final ImmutableList<StatementNode> resultingStatements;
+    private final List<ExpressionNode> conditions;
+    private final List<BlockStatementNode> resultingStatements;
 
     @Nullable
-    private final StatementNode elseStatement;
+    private BlockStatementNode elseStatement;
 
     public IfStatementNode(List<? extends ExpressionNode> conditions,
-            List<? extends StatementNode> resultStatements,
-            @Nullable StatementNode elseStatement) {
+            List<? extends BlockStatementNode> resultStatements,
+            @Nullable BlockStatementNode elseStatement) {
 
-        this.conditions = ImmutableList.copyOf(conditions);
-        this.resultingStatements = ImmutableList.copyOf(resultStatements);
+        this.conditions = new ArrayList<>(conditions);
+        this.resultingStatements = new ArrayList<>(resultStatements);
         this.elseStatement = elseStatement;
     }
 
-    public ImmutableList<ExpressionNode> getConditions() {
+    public List<ExpressionNode> getConditions() {
         return conditions;
     }
 
-    public ImmutableList<StatementNode> getResultingStatements() {
+    public List<BlockStatementNode> getResultingStatements() {
         return resultingStatements;
     }
 
     @Nullable
-    public StatementNode getElseStatement() {
+    public BlockStatementNode getElseStatement() {
         return elseStatement;
+    }
+
+    public void setElseStatement(@Nullable BlockStatementNode elseStatement) {
+        this.elseStatement = elseStatement;
     }
 
     @Override

--- a/src/main/java/io/rodyamirov/brucelang/ast/ProgramNode.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/ProgramNode.java
@@ -1,18 +1,21 @@
 package io.rodyamirov.brucelang.ast;
 
-import com.google.common.collect.ImmutableList;
-
 import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
  * Top level node of the entire program.
  */
-public final class ProgramNode extends ASTNode {
-    private final ImmutableList<StatementNode> statements;
+public final class ProgramNode extends ASTNode implements StatementListHolder {
+    private final List<StatementNode> statements;
 
     public ProgramNode(@Nonnull List<StatementNode> statements) {
-        this.statements = ImmutableList.copyOf(statements);
+        this.statements = statements;
+    }
+
+    @Override
+    public void insertStatementNode(int index, StatementNode statementNode) {
+        statements.add(index, statementNode);
     }
 
     @Override
@@ -20,7 +23,7 @@ public final class ProgramNode extends ASTNode {
         visitor.visitProgram(this);
     }
 
-    public ImmutableList<StatementNode> getStatements() {
+    public List<StatementNode> getStatements() {
         return statements;
     }
 }

--- a/src/main/java/io/rodyamirov/brucelang/ast/StatementListHolder.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/StatementListHolder.java
@@ -1,0 +1,5 @@
+package io.rodyamirov.brucelang.ast;
+
+public interface StatementListHolder {
+    void insertStatementNode(int index, StatementNode statementNode);
+}

--- a/src/main/java/io/rodyamirov/brucelang/ast/UnaryOpExprNode.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/UnaryOpExprNode.java
@@ -3,7 +3,7 @@ package io.rodyamirov.brucelang.ast;
 // TODO -- remove this class and replace it with a function call node
 public final class UnaryOpExprNode extends ExpressionNode {
     private final Operators.UnOp operation;
-    private final ExpressionNode child;
+    private ExpressionNode child;
 
     public UnaryOpExprNode(Operators.UnOp operation, ExpressionNode child) {
         this.operation = operation;
@@ -21,5 +21,9 @@ public final class UnaryOpExprNode extends ExpressionNode {
 
     public ExpressionNode getChild() {
         return child;
+    }
+
+    public void setChild(ExpressionNode child) {
+        this.child = child;
     }
 }

--- a/src/main/java/io/rodyamirov/brucelang/ast/VariableDefinitionNode.java
+++ b/src/main/java/io/rodyamirov/brucelang/ast/VariableDefinitionNode.java
@@ -1,8 +1,8 @@
 package io.rodyamirov.brucelang.ast;
 
 public final class VariableDefinitionNode extends StatementNode {
-    private final VariableDeclarationNode variableDeclarationNode;
-    private final ExpressionNode evalExpr;
+    private VariableDeclarationNode variableDeclarationNode;
+    private ExpressionNode evalExpr;
 
     public VariableDefinitionNode(String varName, ExpressionNode evalExpr) {
         this.variableDeclarationNode = new VariableDeclarationNode(varName);
@@ -18,7 +18,16 @@ public final class VariableDefinitionNode extends StatementNode {
         return variableDeclarationNode;
     }
 
+    public void setVariableDeclarationNode(
+            VariableDeclarationNode variableDeclarationNode) {
+        this.variableDeclarationNode = variableDeclarationNode;
+    }
+
     public ExpressionNode getEvalExpr() {
         return evalExpr;
+    }
+
+    public void setEvalExpr(ExpressionNode evalExpr) {
+        this.evalExpr = evalExpr;
     }
 }

--- a/src/main/java/io/rodyamirov/brucelang/lexparse/BrucelangBaseVisitor.java
+++ b/src/main/java/io/rodyamirov/brucelang/lexparse/BrucelangBaseVisitor.java
@@ -82,7 +82,14 @@ public class BrucelangBaseVisitor<T> extends AbstractParseTreeVisitor<T> impleme
 	 * <p>The default implementation returns the result of calling
 	 * {@link #visitChildren} on {@code ctx}.</p>
 	 */
-	@Override public T visitExprList(BrucelangParser.ExprListContext ctx) { return visitChildren(ctx); }
+	@Override public T visitNoExprs(BrucelangParser.NoExprsContext ctx) { return visitChildren(ctx); }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The default implementation returns the result of calling
+	 * {@link #visitChildren} on {@code ctx}.</p>
+	 */
+	@Override public T visitSomeExprs(BrucelangParser.SomeExprsContext ctx) { return visitChildren(ctx); }
 	/**
 	 * {@inheritDoc}
 	 *

--- a/src/main/java/io/rodyamirov/brucelang/lexparse/BrucelangParser.java
+++ b/src/main/java/io/rodyamirov/brucelang/lexparse/BrucelangParser.java
@@ -621,19 +621,35 @@ public class BrucelangParser extends Parser {
 	}
 
 	public static class ExprListContext extends ParserRuleContext {
+		public ExprListContext(ParserRuleContext parent, int invokingState) {
+			super(parent, invokingState);
+		}
+		@Override public int getRuleIndex() { return RULE_exprList; }
+	 
+		public ExprListContext() { }
+		public void copyFrom(ExprListContext ctx) {
+			super.copyFrom(ctx);
+		}
+	}
+	public static class NoExprsContext extends ExprListContext {
+		public NoExprsContext(ExprListContext ctx) { copyFrom(ctx); }
+		@Override
+		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+			if ( visitor instanceof BrucelangVisitor ) return ((BrucelangVisitor<? extends T>)visitor).visitNoExprs(this);
+			else return visitor.visitChildren(this);
+		}
+	}
+	public static class SomeExprsContext extends ExprListContext {
 		public List<ExprContext> expr() {
 			return getRuleContexts(ExprContext.class);
 		}
 		public ExprContext expr(int i) {
 			return getRuleContext(ExprContext.class,i);
 		}
-		public ExprListContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_exprList; }
+		public SomeExprsContext(ExprListContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof BrucelangVisitor ) return ((BrucelangVisitor<? extends T>)visitor).visitExprList(this);
+			if ( visitor instanceof BrucelangVisitor ) return ((BrucelangVisitor<? extends T>)visitor).visitSomeExprs(this);
 			else return visitor.visitChildren(this);
 		}
 	}
@@ -643,26 +659,47 @@ public class BrucelangParser extends Parser {
 		enterRule(_localctx, 16, RULE_exprList);
 		int _la;
 		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(120);
-			expr();
-			setState(125);
+			setState(129);
 			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__6) {
+			switch (_input.LA(1)) {
+			case T__4:
+				_localctx = new NoExprsContext(_localctx);
+				enterOuterAlt(_localctx, 1);
 				{
+				}
+				break;
+			case T__3:
+			case T__8:
+			case TRUE:
+			case FALSE:
+			case MINUS:
+			case ID:
+			case INT:
+				_localctx = new SomeExprsContext(_localctx);
+				enterOuterAlt(_localctx, 2);
 				{
 				setState(121);
-				match(T__6);
-				setState(122);
 				expr();
-				}
-				}
-				setState(127);
+				setState(126);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
-			}
+				while (_la==T__6) {
+					{
+					{
+					setState(122);
+					match(T__6);
+					setState(123);
+					expr();
+					}
+					}
+					setState(128);
+					_errHandler.sync(this);
+					_la = _input.LA(1);
+				}
+				}
+				break;
+			default:
+				throw new NoViableAltException(this);
 			}
 		}
 		catch (RecognitionException re) {
@@ -714,14 +751,14 @@ public class BrucelangParser extends Parser {
 		ExprContext _localctx = new ExprContext(_ctx, getState());
 		enterRule(_localctx, 18, RULE_expr);
 		try {
-			setState(130);
+			setState(133);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,8,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,9,_ctx) ) {
 			case 1:
 				_localctx = new LambdaExpressionContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(128);
+				setState(131);
 				lambda();
 				}
 				break;
@@ -729,7 +766,7 @@ public class BrucelangParser extends Parser {
 				_localctx = new BooleanExpressionContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(129);
+				setState(132);
 				boolExpr();
 				}
 				break;
@@ -814,18 +851,18 @@ public class BrucelangParser extends Parser {
 		LambdaContext _localctx = new LambdaContext(_ctx, getState());
 		enterRule(_localctx, 20, RULE_lambda);
 		try {
-			setState(150);
+			setState(153);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,9,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,10,_ctx) ) {
 			case 1:
 				_localctx = new OneArgLambdaContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(132);
+				setState(135);
 				match(ID);
-				setState(133);
+				setState(136);
 				match(T__7);
-				setState(134);
+				setState(137);
 				blockStmt();
 				}
 				break;
@@ -833,15 +870,15 @@ public class BrucelangParser extends Parser {
 				_localctx = new MultiArgLambdaContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(135);
-				match(T__3);
-				setState(136);
-				idList();
-				setState(137);
-				match(T__4);
 				setState(138);
-				match(T__7);
+				match(T__3);
 				setState(139);
+				idList();
+				setState(140);
+				match(T__4);
+				setState(141);
+				match(T__7);
+				setState(142);
 				blockStmt();
 				}
 				break;
@@ -849,11 +886,11 @@ public class BrucelangParser extends Parser {
 				_localctx = new OneArgExprLambdaContext(_localctx);
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(141);
+				setState(144);
 				match(ID);
-				setState(142);
+				setState(145);
 				match(T__7);
-				setState(143);
+				setState(146);
 				expr();
 				}
 				break;
@@ -861,15 +898,15 @@ public class BrucelangParser extends Parser {
 				_localctx = new MultiArgExprLambdaContext(_localctx);
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(144);
-				match(T__3);
-				setState(145);
-				idList();
-				setState(146);
-				match(T__4);
 				setState(147);
-				match(T__7);
+				match(T__3);
 				setState(148);
+				idList();
+				setState(149);
+				match(T__4);
+				setState(150);
+				match(T__7);
+				setState(151);
 				expr();
 				}
 				break;
@@ -930,14 +967,14 @@ public class BrucelangParser extends Parser {
 		BoolExprContext _localctx = new BoolExprContext(_ctx, getState());
 		enterRule(_localctx, 22, RULE_boolExpr);
 		try {
-			setState(157);
+			setState(160);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,10,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,11,_ctx) ) {
 			case 1:
 				_localctx = new FallThroughAddExprContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(152);
+				setState(155);
 				addExpr();
 				}
 				break;
@@ -945,11 +982,11 @@ public class BrucelangParser extends Parser {
 				_localctx = new BoolOpExprContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(153);
+				setState(156);
 				addExpr();
-				setState(154);
+				setState(157);
 				boolOp();
-				setState(155);
+				setState(158);
 				addExpr();
 				}
 				break;
@@ -997,21 +1034,21 @@ public class BrucelangParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(159);
+			setState(162);
 			mulExpr();
-			setState(165);
+			setState(168);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==PLUS || _la==MINUS) {
 				{
 				{
-				setState(160);
+				setState(163);
 				addOp();
-				setState(161);
+				setState(164);
 				mulExpr();
 				}
 				}
-				setState(167);
+				setState(170);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -1059,21 +1096,21 @@ public class BrucelangParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(168);
+			setState(171);
 			unaryExpr();
-			setState(174);
+			setState(177);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==TIMES || _la==DIVIDE) {
 				{
 				{
-				setState(169);
+				setState(172);
 				mulOp();
-				setState(170);
+				setState(173);
 				unaryExpr();
 				}
 				}
-				setState(176);
+				setState(179);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -1131,7 +1168,7 @@ public class BrucelangParser extends Parser {
 		UnaryExprContext _localctx = new UnaryExprContext(_ctx, getState());
 		enterRule(_localctx, 28, RULE_unaryExpr);
 		try {
-			setState(181);
+			setState(184);
 			_errHandler.sync(this);
 			switch (_input.LA(1)) {
 			case T__3:
@@ -1143,7 +1180,7 @@ public class BrucelangParser extends Parser {
 				_localctx = new FallThroughBaseExprContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(177);
+				setState(180);
 				baseExpr();
 				}
 				break;
@@ -1151,9 +1188,9 @@ public class BrucelangParser extends Parser {
 				_localctx = new NestedUnaryExprContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(178);
+				setState(181);
 				unaryOp();
-				setState(179);
+				setState(182);
 				unaryExpr();
 				}
 				break;
@@ -1249,18 +1286,18 @@ public class BrucelangParser extends Parser {
 		enterRule(_localctx, 30, RULE_baseExpr);
 		int _la;
 		try {
-			setState(196);
+			setState(199);
 			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,15,_ctx) ) {
+			switch ( getInterpreter().adaptivePredict(_input,16,_ctx) ) {
 			case 1:
 				_localctx = new ParenExprContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(183);
+				setState(186);
 				match(T__3);
-				setState(184);
+				setState(187);
 				expr();
-				setState(185);
+				setState(188);
 				match(T__4);
 				}
 				break;
@@ -1268,7 +1305,7 @@ public class BrucelangParser extends Parser {
 				_localctx = new FallThroughFnCallContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(187);
+				setState(190);
 				fnCall();
 				}
 				break;
@@ -1276,7 +1313,7 @@ public class BrucelangParser extends Parser {
 				_localctx = new VariableReferenceContext(_localctx);
 				enterOuterAlt(_localctx, 3);
 				{
-				setState(188);
+				setState(191);
 				match(ID);
 				}
 				break;
@@ -1284,7 +1321,7 @@ public class BrucelangParser extends Parser {
 				_localctx = new NumConstContext(_localctx);
 				enterOuterAlt(_localctx, 4);
 				{
-				setState(189);
+				setState(192);
 				match(INT);
 				}
 				break;
@@ -1292,19 +1329,19 @@ public class BrucelangParser extends Parser {
 				_localctx = new StringConstContext(_localctx);
 				enterOuterAlt(_localctx, 5);
 				{
-				setState(190);
+				setState(193);
 				match(T__8);
-				setState(192);
+				setState(195);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 				if (_la==STRING_CONST) {
 					{
-					setState(191);
+					setState(194);
 					match(STRING_CONST);
 					}
 				}
 
-				setState(194);
+				setState(197);
 				match(T__8);
 				}
 				break;
@@ -1312,7 +1349,7 @@ public class BrucelangParser extends Parser {
 				_localctx = new BoolConstContext(_localctx);
 				enterOuterAlt(_localctx, 6);
 				{
-				setState(195);
+				setState(198);
 				boolVal();
 				}
 				break;
@@ -1371,20 +1408,20 @@ public class BrucelangParser extends Parser {
 		FnCallContext _localctx = new FnCallContext(_ctx, getState());
 		enterRule(_localctx, 32, RULE_fnCall);
 		try {
-			setState(210);
+			setState(213);
 			_errHandler.sync(this);
 			switch (_input.LA(1)) {
 			case ID:
 				_localctx = new NamedFnCallContext(_localctx);
 				enterOuterAlt(_localctx, 1);
 				{
-				setState(198);
-				match(ID);
-				setState(199);
-				match(T__3);
-				setState(200);
-				exprList();
 				setState(201);
+				match(ID);
+				setState(202);
+				match(T__3);
+				setState(203);
+				exprList();
+				setState(204);
 				match(T__4);
 				}
 				break;
@@ -1392,17 +1429,17 @@ public class BrucelangParser extends Parser {
 				_localctx = new AnonFnCallContext(_localctx);
 				enterOuterAlt(_localctx, 2);
 				{
-				setState(203);
-				match(T__3);
-				setState(204);
-				lambda();
-				setState(205);
-				match(T__4);
 				setState(206);
 				match(T__3);
 				setState(207);
-				exprList();
+				lambda();
 				setState(208);
+				match(T__4);
+				setState(209);
+				match(T__3);
+				setState(210);
+				exprList();
+				setState(211);
 				match(T__4);
 				}
 				break;
@@ -1442,7 +1479,7 @@ public class BrucelangParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(212);
+			setState(215);
 			_la = _input.LA(1);
 			if ( !(_la==AND || _la==OR) ) {
 			_errHandler.recoverInline(this);
@@ -1490,7 +1527,7 @@ public class BrucelangParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(214);
+			setState(217);
 			_la = _input.LA(1);
 			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE) | (1L << EQ) | (1L << NEQ))) != 0)) ) {
 			_errHandler.recoverInline(this);
@@ -1534,7 +1571,7 @@ public class BrucelangParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(216);
+			setState(219);
 			_la = _input.LA(1);
 			if ( !(_la==TRUE || _la==FALSE) ) {
 			_errHandler.recoverInline(this);
@@ -1578,7 +1615,7 @@ public class BrucelangParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(218);
+			setState(221);
 			_la = _input.LA(1);
 			if ( !(_la==PLUS || _la==MINUS) ) {
 			_errHandler.recoverInline(this);
@@ -1622,7 +1659,7 @@ public class BrucelangParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(220);
+			setState(223);
 			_la = _input.LA(1);
 			if ( !(_la==TIMES || _la==DIVIDE) ) {
 			_errHandler.recoverInline(this);
@@ -1664,7 +1701,7 @@ public class BrucelangParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(222);
+			setState(225);
 			match(MINUS);
 			}
 		}
@@ -1680,7 +1717,7 @@ public class BrucelangParser extends Parser {
 	}
 
 	public static final String _serializedATN =
-		"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3%\u00e3\4\2\t\2\4"+
+		"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3%\u00e6\4\2\t\2\4"+
 		"\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
 		"\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
 		"\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\3\2\7\2\62"+
@@ -1688,68 +1725,70 @@ public class BrucelangParser extends Parser {
 		"\3\4\3\5\3\5\7\5F\n\5\f\5\16\5I\13\5\3\5\3\5\3\6\3\6\3\6\3\6\3\6\3\6\3"+
 		"\6\3\6\3\6\3\6\3\6\3\6\7\6Y\n\6\f\6\16\6\\\13\6\3\6\3\6\5\6`\n\6\3\7\3"+
 		"\7\3\7\3\7\3\7\3\7\3\b\3\b\3\b\3\b\3\b\3\b\3\b\3\b\3\t\3\t\3\t\3\t\7\t"+
-		"t\n\t\f\t\16\tw\13\t\5\ty\n\t\3\n\3\n\3\n\7\n~\n\n\f\n\16\n\u0081\13\n"+
-		"\3\13\3\13\5\13\u0085\n\13\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f"+
-		"\3\f\3\f\3\f\3\f\3\f\3\f\3\f\5\f\u0099\n\f\3\r\3\r\3\r\3\r\3\r\5\r\u00a0"+
-		"\n\r\3\16\3\16\3\16\3\16\7\16\u00a6\n\16\f\16\16\16\u00a9\13\16\3\17\3"+
-		"\17\3\17\3\17\7\17\u00af\n\17\f\17\16\17\u00b2\13\17\3\20\3\20\3\20\3"+
-		"\20\5\20\u00b8\n\20\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\5\21"+
-		"\u00c3\n\21\3\21\3\21\5\21\u00c7\n\21\3\22\3\22\3\22\3\22\3\22\3\22\3"+
-		"\22\3\22\3\22\3\22\3\22\3\22\5\22\u00d5\n\22\3\23\3\23\3\24\3\24\3\25"+
-		"\3\25\3\26\3\26\3\27\3\27\3\30\3\30\3\30\2\2\31\2\4\6\b\n\f\16\20\22\24"+
-		"\26\30\32\34\36 \"$&(*,.\2\7\3\2\27\30\3\2\35\"\3\2\f\r\3\2\31\32\3\2"+
-		"\33\34\2\u00e5\2\63\3\2\2\2\4=\3\2\2\2\6?\3\2\2\2\bC\3\2\2\2\nL\3\2\2"+
-		"\2\fa\3\2\2\2\16g\3\2\2\2\20x\3\2\2\2\22z\3\2\2\2\24\u0084\3\2\2\2\26"+
-		"\u0098\3\2\2\2\30\u009f\3\2\2\2\32\u00a1\3\2\2\2\34\u00aa\3\2\2\2\36\u00b7"+
-		"\3\2\2\2 \u00c6\3\2\2\2\"\u00d4\3\2\2\2$\u00d6\3\2\2\2&\u00d8\3\2\2\2"+
-		"(\u00da\3\2\2\2*\u00dc\3\2\2\2,\u00de\3\2\2\2.\u00e0\3\2\2\2\60\62\5\4"+
-		"\3\2\61\60\3\2\2\2\62\65\3\2\2\2\63\61\3\2\2\2\63\64\3\2\2\2\64\66\3\2"+
-		"\2\2\65\63\3\2\2\2\66\67\7\2\2\3\67\3\3\2\2\28>\5\b\5\29>\5\16\b\2:>\5"+
-		"\f\7\2;>\5\6\4\2<>\5\n\6\2=8\3\2\2\2=9\3\2\2\2=:\3\2\2\2=;\3\2\2\2=<\3"+
-		"\2\2\2>\5\3\2\2\2?@\7\20\2\2@A\5\24\13\2AB\7\3\2\2B\7\3\2\2\2CG\7\4\2"+
-		"\2DF\5\4\3\2ED\3\2\2\2FI\3\2\2\2GE\3\2\2\2GH\3\2\2\2HJ\3\2\2\2IG\3\2\2"+
-		"\2JK\7\5\2\2K\t\3\2\2\2LM\7\23\2\2MN\7\6\2\2NO\5\24\13\2OP\7\7\2\2PZ\5"+
-		"\b\5\2QR\7\24\2\2RS\7\23\2\2ST\7\6\2\2TU\5\24\13\2UV\7\7\2\2VW\5\b\5\2"+
-		"WY\3\2\2\2XQ\3\2\2\2Y\\\3\2\2\2ZX\3\2\2\2Z[\3\2\2\2[_\3\2\2\2\\Z\3\2\2"+
-		"\2]^\7\24\2\2^`\5\b\5\2_]\3\2\2\2_`\3\2\2\2`\13\3\2\2\2ab\7\25\2\2bc\7"+
-		"#\2\2cd\7\b\2\2de\5\24\13\2ef\7\3\2\2f\r\3\2\2\2gh\7\16\2\2hi\7#\2\2i"+
-		"j\7\6\2\2jk\5\20\t\2kl\7\7\2\2lm\7\21\2\2mn\5\b\5\2n\17\3\2\2\2oy\3\2"+
-		"\2\2pu\7#\2\2qr\7\t\2\2rt\7#\2\2sq\3\2\2\2tw\3\2\2\2us\3\2\2\2uv\3\2\2"+
-		"\2vy\3\2\2\2wu\3\2\2\2xo\3\2\2\2xp\3\2\2\2y\21\3\2\2\2z\177\5\24\13\2"+
-		"{|\7\t\2\2|~\5\24\13\2}{\3\2\2\2~\u0081\3\2\2\2\177}\3\2\2\2\177\u0080"+
-		"\3\2\2\2\u0080\23\3\2\2\2\u0081\177\3\2\2\2\u0082\u0085\5\26\f\2\u0083"+
-		"\u0085\5\30\r\2\u0084\u0082\3\2\2\2\u0084\u0083\3\2\2\2\u0085\25\3\2\2"+
-		"\2\u0086\u0087\7#\2\2\u0087\u0088\7\n\2\2\u0088\u0099\5\b\5\2\u0089\u008a"+
-		"\7\6\2\2\u008a\u008b\5\20\t\2\u008b\u008c\7\7\2\2\u008c\u008d\7\n\2\2"+
-		"\u008d\u008e\5\b\5\2\u008e\u0099\3\2\2\2\u008f\u0090\7#\2\2\u0090\u0091"+
-		"\7\n\2\2\u0091\u0099\5\24\13\2\u0092\u0093\7\6\2\2\u0093\u0094\5\20\t"+
-		"\2\u0094\u0095\7\7\2\2\u0095\u0096\7\n\2\2\u0096\u0097\5\24\13\2\u0097"+
-		"\u0099\3\2\2\2\u0098\u0086\3\2\2\2\u0098\u0089\3\2\2\2\u0098\u008f\3\2"+
-		"\2\2\u0098\u0092\3\2\2\2\u0099\27\3\2\2\2\u009a\u00a0\5\32\16\2\u009b"+
-		"\u009c\5\32\16\2\u009c\u009d\5$\23\2\u009d\u009e\5\32\16\2\u009e\u00a0"+
-		"\3\2\2\2\u009f\u009a\3\2\2\2\u009f\u009b\3\2\2\2\u00a0\31\3\2\2\2\u00a1"+
-		"\u00a7\5\34\17\2\u00a2\u00a3\5*\26\2\u00a3\u00a4\5\34\17\2\u00a4\u00a6"+
-		"\3\2\2\2\u00a5\u00a2\3\2\2\2\u00a6\u00a9\3\2\2\2\u00a7\u00a5\3\2\2\2\u00a7"+
-		"\u00a8\3\2\2\2\u00a8\33\3\2\2\2\u00a9\u00a7\3\2\2\2\u00aa\u00b0\5\36\20"+
-		"\2\u00ab\u00ac\5,\27\2\u00ac\u00ad\5\36\20\2\u00ad\u00af\3\2\2\2\u00ae"+
-		"\u00ab\3\2\2\2\u00af\u00b2\3\2\2\2\u00b0\u00ae\3\2\2\2\u00b0\u00b1\3\2"+
-		"\2\2\u00b1\35\3\2\2\2\u00b2\u00b0\3\2\2\2\u00b3\u00b8\5 \21\2\u00b4\u00b5"+
-		"\5.\30\2\u00b5\u00b6\5\36\20\2\u00b6\u00b8\3\2\2\2\u00b7\u00b3\3\2\2\2"+
-		"\u00b7\u00b4\3\2\2\2\u00b8\37\3\2\2\2\u00b9\u00ba\7\6\2\2\u00ba\u00bb"+
-		"\5\24\13\2\u00bb\u00bc\7\7\2\2\u00bc\u00c7\3\2\2\2\u00bd\u00c7\5\"\22"+
-		"\2\u00be\u00c7\7#\2\2\u00bf\u00c7\7$\2\2\u00c0\u00c2\7\13\2\2\u00c1\u00c3"+
-		"\7\26\2\2\u00c2\u00c1\3\2\2\2\u00c2\u00c3\3\2\2\2\u00c3\u00c4\3\2\2\2"+
-		"\u00c4\u00c7\7\13\2\2\u00c5\u00c7\5(\25\2\u00c6\u00b9\3\2\2\2\u00c6\u00bd"+
-		"\3\2\2\2\u00c6\u00be\3\2\2\2\u00c6\u00bf\3\2\2\2\u00c6\u00c0\3\2\2\2\u00c6"+
-		"\u00c5\3\2\2\2\u00c7!\3\2\2\2\u00c8\u00c9\7#\2\2\u00c9\u00ca\7\6\2\2\u00ca"+
-		"\u00cb\5\22\n\2\u00cb\u00cc\7\7\2\2\u00cc\u00d5\3\2\2\2\u00cd\u00ce\7"+
-		"\6\2\2\u00ce\u00cf\5\26\f\2\u00cf\u00d0\7\7\2\2\u00d0\u00d1\7\6\2\2\u00d1"+
-		"\u00d2\5\22\n\2\u00d2\u00d3\7\7\2\2\u00d3\u00d5\3\2\2\2\u00d4\u00c8\3"+
-		"\2\2\2\u00d4\u00cd\3\2\2\2\u00d5#\3\2\2\2\u00d6\u00d7\t\2\2\2\u00d7%\3"+
-		"\2\2\2\u00d8\u00d9\t\3\2\2\u00d9\'\3\2\2\2\u00da\u00db\t\4\2\2\u00db)"+
-		"\3\2\2\2\u00dc\u00dd\t\5\2\2\u00dd+\3\2\2\2\u00de\u00df\t\6\2\2\u00df"+
-		"-\3\2\2\2\u00e0\u00e1\7\32\2\2\u00e1/\3\2\2\2\23\63=GZ_ux\177\u0084\u0098"+
-		"\u009f\u00a7\u00b0\u00b7\u00c2\u00c6\u00d4";
+		"t\n\t\f\t\16\tw\13\t\5\ty\n\t\3\n\3\n\3\n\3\n\7\n\177\n\n\f\n\16\n\u0082"+
+		"\13\n\5\n\u0084\n\n\3\13\3\13\5\13\u0088\n\13\3\f\3\f\3\f\3\f\3\f\3\f"+
+		"\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\5\f\u009c\n\f\3\r\3\r"+
+		"\3\r\3\r\3\r\5\r\u00a3\n\r\3\16\3\16\3\16\3\16\7\16\u00a9\n\16\f\16\16"+
+		"\16\u00ac\13\16\3\17\3\17\3\17\3\17\7\17\u00b2\n\17\f\17\16\17\u00b5\13"+
+		"\17\3\20\3\20\3\20\3\20\5\20\u00bb\n\20\3\21\3\21\3\21\3\21\3\21\3\21"+
+		"\3\21\3\21\3\21\5\21\u00c6\n\21\3\21\3\21\5\21\u00ca\n\21\3\22\3\22\3"+
+		"\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\5\22\u00d8\n\22\3\23"+
+		"\3\23\3\24\3\24\3\25\3\25\3\26\3\26\3\27\3\27\3\30\3\30\3\30\2\2\31\2"+
+		"\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\2\7\3\2\27\30\3\2\35\""+
+		"\3\2\f\r\3\2\31\32\3\2\33\34\2\u00e9\2\63\3\2\2\2\4=\3\2\2\2\6?\3\2\2"+
+		"\2\bC\3\2\2\2\nL\3\2\2\2\fa\3\2\2\2\16g\3\2\2\2\20x\3\2\2\2\22\u0083\3"+
+		"\2\2\2\24\u0087\3\2\2\2\26\u009b\3\2\2\2\30\u00a2\3\2\2\2\32\u00a4\3\2"+
+		"\2\2\34\u00ad\3\2\2\2\36\u00ba\3\2\2\2 \u00c9\3\2\2\2\"\u00d7\3\2\2\2"+
+		"$\u00d9\3\2\2\2&\u00db\3\2\2\2(\u00dd\3\2\2\2*\u00df\3\2\2\2,\u00e1\3"+
+		"\2\2\2.\u00e3\3\2\2\2\60\62\5\4\3\2\61\60\3\2\2\2\62\65\3\2\2\2\63\61"+
+		"\3\2\2\2\63\64\3\2\2\2\64\66\3\2\2\2\65\63\3\2\2\2\66\67\7\2\2\3\67\3"+
+		"\3\2\2\28>\5\b\5\29>\5\16\b\2:>\5\f\7\2;>\5\6\4\2<>\5\n\6\2=8\3\2\2\2"+
+		"=9\3\2\2\2=:\3\2\2\2=;\3\2\2\2=<\3\2\2\2>\5\3\2\2\2?@\7\20\2\2@A\5\24"+
+		"\13\2AB\7\3\2\2B\7\3\2\2\2CG\7\4\2\2DF\5\4\3\2ED\3\2\2\2FI\3\2\2\2GE\3"+
+		"\2\2\2GH\3\2\2\2HJ\3\2\2\2IG\3\2\2\2JK\7\5\2\2K\t\3\2\2\2LM\7\23\2\2M"+
+		"N\7\6\2\2NO\5\24\13\2OP\7\7\2\2PZ\5\b\5\2QR\7\24\2\2RS\7\23\2\2ST\7\6"+
+		"\2\2TU\5\24\13\2UV\7\7\2\2VW\5\b\5\2WY\3\2\2\2XQ\3\2\2\2Y\\\3\2\2\2ZX"+
+		"\3\2\2\2Z[\3\2\2\2[_\3\2\2\2\\Z\3\2\2\2]^\7\24\2\2^`\5\b\5\2_]\3\2\2\2"+
+		"_`\3\2\2\2`\13\3\2\2\2ab\7\25\2\2bc\7#\2\2cd\7\b\2\2de\5\24\13\2ef\7\3"+
+		"\2\2f\r\3\2\2\2gh\7\16\2\2hi\7#\2\2ij\7\6\2\2jk\5\20\t\2kl\7\7\2\2lm\7"+
+		"\21\2\2mn\5\b\5\2n\17\3\2\2\2oy\3\2\2\2pu\7#\2\2qr\7\t\2\2rt\7#\2\2sq"+
+		"\3\2\2\2tw\3\2\2\2us\3\2\2\2uv\3\2\2\2vy\3\2\2\2wu\3\2\2\2xo\3\2\2\2x"+
+		"p\3\2\2\2y\21\3\2\2\2z\u0084\3\2\2\2{\u0080\5\24\13\2|}\7\t\2\2}\177\5"+
+		"\24\13\2~|\3\2\2\2\177\u0082\3\2\2\2\u0080~\3\2\2\2\u0080\u0081\3\2\2"+
+		"\2\u0081\u0084\3\2\2\2\u0082\u0080\3\2\2\2\u0083z\3\2\2\2\u0083{\3\2\2"+
+		"\2\u0084\23\3\2\2\2\u0085\u0088\5\26\f\2\u0086\u0088\5\30\r\2\u0087\u0085"+
+		"\3\2\2\2\u0087\u0086\3\2\2\2\u0088\25\3\2\2\2\u0089\u008a\7#\2\2\u008a"+
+		"\u008b\7\n\2\2\u008b\u009c\5\b\5\2\u008c\u008d\7\6\2\2\u008d\u008e\5\20"+
+		"\t\2\u008e\u008f\7\7\2\2\u008f\u0090\7\n\2\2\u0090\u0091\5\b\5\2\u0091"+
+		"\u009c\3\2\2\2\u0092\u0093\7#\2\2\u0093\u0094\7\n\2\2\u0094\u009c\5\24"+
+		"\13\2\u0095\u0096\7\6\2\2\u0096\u0097\5\20\t\2\u0097\u0098\7\7\2\2\u0098"+
+		"\u0099\7\n\2\2\u0099\u009a\5\24\13\2\u009a\u009c\3\2\2\2\u009b\u0089\3"+
+		"\2\2\2\u009b\u008c\3\2\2\2\u009b\u0092\3\2\2\2\u009b\u0095\3\2\2\2\u009c"+
+		"\27\3\2\2\2\u009d\u00a3\5\32\16\2\u009e\u009f\5\32\16\2\u009f\u00a0\5"+
+		"$\23\2\u00a0\u00a1\5\32\16\2\u00a1\u00a3\3\2\2\2\u00a2\u009d\3\2\2\2\u00a2"+
+		"\u009e\3\2\2\2\u00a3\31\3\2\2\2\u00a4\u00aa\5\34\17\2\u00a5\u00a6\5*\26"+
+		"\2\u00a6\u00a7\5\34\17\2\u00a7\u00a9\3\2\2\2\u00a8\u00a5\3\2\2\2\u00a9"+
+		"\u00ac\3\2\2\2\u00aa\u00a8\3\2\2\2\u00aa\u00ab\3\2\2\2\u00ab\33\3\2\2"+
+		"\2\u00ac\u00aa\3\2\2\2\u00ad\u00b3\5\36\20\2\u00ae\u00af\5,\27\2\u00af"+
+		"\u00b0\5\36\20\2\u00b0\u00b2\3\2\2\2\u00b1\u00ae\3\2\2\2\u00b2\u00b5\3"+
+		"\2\2\2\u00b3\u00b1\3\2\2\2\u00b3\u00b4\3\2\2\2\u00b4\35\3\2\2\2\u00b5"+
+		"\u00b3\3\2\2\2\u00b6\u00bb\5 \21\2\u00b7\u00b8\5.\30\2\u00b8\u00b9\5\36"+
+		"\20\2\u00b9\u00bb\3\2\2\2\u00ba\u00b6\3\2\2\2\u00ba\u00b7\3\2\2\2\u00bb"+
+		"\37\3\2\2\2\u00bc\u00bd\7\6\2\2\u00bd\u00be\5\24\13\2\u00be\u00bf\7\7"+
+		"\2\2\u00bf\u00ca\3\2\2\2\u00c0\u00ca\5\"\22\2\u00c1\u00ca\7#\2\2\u00c2"+
+		"\u00ca\7$\2\2\u00c3\u00c5\7\13\2\2\u00c4\u00c6\7\26\2\2\u00c5\u00c4\3"+
+		"\2\2\2\u00c5\u00c6\3\2\2\2\u00c6\u00c7\3\2\2\2\u00c7\u00ca\7\13\2\2\u00c8"+
+		"\u00ca\5(\25\2\u00c9\u00bc\3\2\2\2\u00c9\u00c0\3\2\2\2\u00c9\u00c1\3\2"+
+		"\2\2\u00c9\u00c2\3\2\2\2\u00c9\u00c3\3\2\2\2\u00c9\u00c8\3\2\2\2\u00ca"+
+		"!\3\2\2\2\u00cb\u00cc\7#\2\2\u00cc\u00cd\7\6\2\2\u00cd\u00ce\5\22\n\2"+
+		"\u00ce\u00cf\7\7\2\2\u00cf\u00d8\3\2\2\2\u00d0\u00d1\7\6\2\2\u00d1\u00d2"+
+		"\5\26\f\2\u00d2\u00d3\7\7\2\2\u00d3\u00d4\7\6\2\2\u00d4\u00d5\5\22\n\2"+
+		"\u00d5\u00d6\7\7\2\2\u00d6\u00d8\3\2\2\2\u00d7\u00cb\3\2\2\2\u00d7\u00d0"+
+		"\3\2\2\2\u00d8#\3\2\2\2\u00d9\u00da\t\2\2\2\u00da%\3\2\2\2\u00db\u00dc"+
+		"\t\3\2\2\u00dc\'\3\2\2\2\u00dd\u00de\t\4\2\2\u00de)\3\2\2\2\u00df\u00e0"+
+		"\t\5\2\2\u00e0+\3\2\2\2\u00e1\u00e2\t\6\2\2\u00e2-\3\2\2\2\u00e3\u00e4"+
+		"\7\32\2\2\u00e4/\3\2\2\2\24\63=GZ_ux\u0080\u0083\u0087\u009b\u00a2\u00aa"+
+		"\u00b3\u00ba\u00c5\u00c9\u00d7";
 	public static final ATN _ATN =
 		new ATNDeserializer().deserialize(_serializedATN.toCharArray());
 	static {

--- a/src/main/java/io/rodyamirov/brucelang/lexparse/BrucelangVisitor.java
+++ b/src/main/java/io/rodyamirov/brucelang/lexparse/BrucelangVisitor.java
@@ -69,11 +69,19 @@ public interface BrucelangVisitor<T> extends ParseTreeVisitor<T> {
 	 */
 	T visitSomeIds(BrucelangParser.SomeIdsContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link BrucelangParser#exprList}.
+	 * Visit a parse tree produced by the {@code noExprs}
+	 * labeled alternative in {@link BrucelangParser#exprList}.
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
-	T visitExprList(BrucelangParser.ExprListContext ctx);
+	T visitNoExprs(BrucelangParser.NoExprsContext ctx);
+	/**
+	 * Visit a parse tree produced by the {@code someExprs}
+	 * labeled alternative in {@link BrucelangParser#exprList}.
+	 * @param ctx the parse tree
+	 * @return the visitor result
+	 */
+	T visitSomeExprs(BrucelangParser.SomeExprsContext ctx);
 	/**
 	 * Visit a parse tree produced by the {@code lambdaExpression}
 	 * labeled alternative in {@link BrucelangParser#expr}.

--- a/src/main/java/io/rodyamirov/brucelang/staticanalysis/LambdaDesugarer.java
+++ b/src/main/java/io/rodyamirov/brucelang/staticanalysis/LambdaDesugarer.java
@@ -1,0 +1,244 @@
+package io.rodyamirov.brucelang.staticanalysis;
+
+import io.rodyamirov.brucelang.ast.ASTNode;
+import io.rodyamirov.brucelang.ast.BinOpExprNode;
+import io.rodyamirov.brucelang.ast.BlockStatementNode;
+import io.rodyamirov.brucelang.ast.BoolExprNode;
+import io.rodyamirov.brucelang.ast.DoStatementNode;
+import io.rodyamirov.brucelang.ast.ExpressionNode;
+import io.rodyamirov.brucelang.ast.FunctionCallNode;
+import io.rodyamirov.brucelang.ast.FunctionExprNode;
+import io.rodyamirov.brucelang.ast.IfStatementNode;
+import io.rodyamirov.brucelang.ast.IntExprNode;
+import io.rodyamirov.brucelang.ast.ProgramNode;
+import io.rodyamirov.brucelang.ast.ReturnStatementNode;
+import io.rodyamirov.brucelang.ast.StatementListHolder;
+import io.rodyamirov.brucelang.ast.StatementNode;
+import io.rodyamirov.brucelang.ast.StringExprNode;
+import io.rodyamirov.brucelang.ast.UnaryOpExprNode;
+import io.rodyamirov.brucelang.ast.VariableDeclarationNode;
+import io.rodyamirov.brucelang.ast.VariableDefinitionNode;
+import io.rodyamirov.brucelang.ast.VariableReferenceNode;
+import io.rodyamirov.brucelang.util.collections.ArrayStack;
+import io.rodyamirov.brucelang.util.collections.Stack;
+import io.rodyamirov.brucelang.util.collections.StackHelper;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A desugarer class which replaces anonymous functions (that is, lambdas which are defined but not
+ * assigned to a variable) with named functions (so every functions is introduced in the form
+ * `let f = args => {stmts}`)
+ */
+public class LambdaDesugarer {
+    private LambdaDesugarer() {
+    }
+
+    public static void removeAnonymousFunctions(ProgramNode programNode) {
+        new LambdaDesugarerVisitor().visitProgram(programNode);
+    }
+
+    private interface NodeReplacer {
+        void replaceNode(ASTNode toReplace);
+    }
+
+    private static class LambdaDesugarerVisitor implements ASTNode.ASTVisitor {
+        private final Stack<StatementListHolder> stmtListHolders = new ArrayStack<>();
+
+        private final Stack<NodeReplacer> nodeReplacers = new ArrayStack<>();
+        private final StackHelper<NodeReplacer> replacerHelper = new StackHelper<>(nodeReplacers);
+
+        // This is the current index of the current stmtListHolder to insert a new statement at
+        private Stack<AtomicInteger> insertionPoints = new ArrayStack<>();
+
+        @Override
+        public void visitProgram(ProgramNode programNode) {
+            stmtListHolders.push(programNode);
+
+            AtomicInteger stmtIndex = new AtomicInteger(0);
+            insertionPoints.push(stmtIndex);
+            while (stmtIndex.get() < programNode.getStatements().size()) {
+                replacerHelper.safePushPop(
+                        node -> {
+                            int insertAt = stmtIndex.getAndIncrement();
+                            programNode.insertStatementNode(insertAt, (StatementNode) node);
+                        },
+                        () -> programNode.getStatements().get(stmtIndex.get()).accept(this)
+                );
+                stmtIndex.incrementAndGet();
+            }
+
+            insertionPoints.pop();
+            stmtListHolders.pop();
+        }
+
+        @Override
+        public void visitFunctionExpr(FunctionExprNode functionDefinitionNode) {
+            if (functionDefinitionNode.isDefExpr()) {
+                // then we're cool
+                AtomicInteger counter = new AtomicInteger(0);
+                for (VariableDeclarationNode param : functionDefinitionNode.getParameterNodes()) {
+                    replacerHelper.safePushPop(
+                            node -> functionDefinitionNode.getParameterNodes().set(counter.get(), (VariableDeclarationNode) node),
+                            () -> param.accept(this)
+                    );
+                    counter.incrementAndGet();
+                }
+
+                counter.set(0);
+                for (StatementNode defStmt : functionDefinitionNode.getDefinitionStatements()) {
+                    replacerHelper.safePushPop(
+                            node -> functionDefinitionNode.getDefinitionStatements().set(counter.get(), (StatementNode) node),
+                            () -> defStmt.accept(this)
+                    );
+                    counter.incrementAndGet();
+                }
+            } else {
+                // make a new node, insert it at the above block
+                String anonName = functionDefinitionNode.getSelfName();
+
+                stmtListHolders.peek().insertStatementNode(
+                        insertionPoints.peek().get(),
+                        new VariableDefinitionNode(anonName, functionDefinitionNode)
+                );
+
+                nodeReplacers.peek().replaceNode(
+                        new VariableReferenceNode(anonName)
+                );
+            }
+        }
+
+        @Override
+        public void visitVariableDefinition(VariableDefinitionNode variableDefinitionNode) {
+            replacerHelper.safePushPop(
+                    node -> variableDefinitionNode.setVariableDeclarationNode((VariableDeclarationNode) node),
+                    () -> variableDefinitionNode.getVariableDeclarationNode().accept(this)
+            );
+
+            variableDefinitionNode.getEvalExpr().setDefExpr(true);
+            replacerHelper.safePushPop(
+                    node -> variableDefinitionNode.setEvalExpr((ExpressionNode) node),
+                    () -> variableDefinitionNode.getEvalExpr().accept(this)
+            );
+        }
+
+        @Override
+        public void visitVariableDeclaration(VariableDeclarationNode variableDeclarationNode) {
+            // do nothing! This node is terminal and doesn't need to be desugared
+        }
+
+        @Override
+        public void visitBlockStatement(BlockStatementNode blockStatementNode) {
+            // TODO: it is known that this does not work
+            stmtListHolders.push(blockStatementNode);
+            insertionPoints.push(new AtomicInteger(0));
+
+            AtomicInteger counter = new AtomicInteger(0);
+            for (StatementNode child : blockStatementNode.getStatements()) {
+                replacerHelper.safePushPop(
+                        node -> blockStatementNode.getStatements().set(counter.get(), (StatementNode) node),
+                        () -> child.accept(this)
+                );
+                counter.incrementAndGet();
+                insertionPoints.peek().incrementAndGet();
+            }
+
+            insertionPoints.pop();
+            stmtListHolders.pop();
+        }
+
+        @Override
+        public void visitDoStatement(DoStatementNode doStatementNode) {
+            doStatementNode.getEvalExpression().accept(this);
+        }
+
+        @Override
+        public void visitReturnStatement(ReturnStatementNode returnStatementNode) {
+            returnStatementNode.getEvalExpression().accept(this);
+        }
+
+        @Override
+        public void visitIfStatement(IfStatementNode ifStatementNode) {
+            AtomicInteger counter = new AtomicInteger(0);
+            for (int i = 0; i < ifStatementNode.getConditions().size(); i++) {
+                replacerHelper.safePushPop(
+                        node -> ifStatementNode.getConditions().set(counter.get(), (ExpressionNode) node),
+                        () -> ifStatementNode.getConditions().get(counter.get()).accept(this)
+                );
+
+                replacerHelper.safePushPop(
+                        node -> ifStatementNode.getResultingStatements().set(counter.get(), (BlockStatementNode) node),
+                        () -> ifStatementNode.getResultingStatements().get(counter.get()).accept(this)
+                );
+
+                counter.incrementAndGet();
+            }
+
+            if (ifStatementNode.getElseStatement() != null) {
+                replacerHelper.safePushPop(
+                        node -> ifStatementNode.setElseStatement((BlockStatementNode) node),
+                        () -> ifStatementNode.getElseStatement().accept(this)
+                );
+            }
+        }
+
+        @Override
+        public void visitFunctionCallNode(FunctionCallNode functionCallNode) {
+            replacerHelper.safePushPop(
+                    node -> functionCallNode.setFunctionNode((ExpressionNode) node),
+                    () -> functionCallNode.getFunctionNode().accept(this)
+            );
+
+            AtomicInteger counter = new AtomicInteger(0);
+            for (ExpressionNode arg : functionCallNode.getArguments()) {
+                replacerHelper.safePushPop(
+                        node -> functionCallNode.getArguments().set(counter.get(), (ExpressionNode) node),
+                        () -> arg.accept(this)
+                );
+
+                counter.incrementAndGet();
+            }
+        }
+
+        @Override
+        public void visitBinOpExprNode(BinOpExprNode binOpExprNode) {
+            replacerHelper.safePushPop(
+                    node -> binOpExprNode.setLeftChild((ExpressionNode) node),
+                    () -> binOpExprNode.getLeftChild().accept(this)
+            );
+
+            replacerHelper.safePushPop(
+                    node -> binOpExprNode.setRightChild((ExpressionNode) node),
+                    () -> binOpExprNode.getRightChild().accept(this)
+            );
+        }
+
+        @Override
+        public void visitUnaryOpExprNode(UnaryOpExprNode unaryOpExprNode) {
+            replacerHelper.safePushPop(
+                    node -> unaryOpExprNode.setChild((ExpressionNode) node),
+                    () -> unaryOpExprNode.getChild().accept(this)
+            );
+        }
+
+        @Override
+        public void visitIntExprNode(IntExprNode integerNode) {
+            // do nothing! This node is terminal and doesn't need to be desugared
+        }
+
+        @Override
+        public void visitBoolExprNode(BoolExprNode booleanNode) {
+            // do nothing! This node is terminal and doesn't need to be desugared
+        }
+
+        @Override
+        public void visitStringExprNode(StringExprNode stringExprNode) {
+            // do nothing! This node is terminal and doesn't need to be desugared
+        }
+
+        @Override
+        public void visitVariableReferenceNode(VariableReferenceNode variableReferenceNode) {
+            // do nothing! This node is terminal and doesn't need to be desugared
+        }
+    }
+}

--- a/src/main/java/io/rodyamirov/brucelang/staticanalysis/NameRegistrar.java
+++ b/src/main/java/io/rodyamirov/brucelang/staticanalysis/NameRegistrar.java
@@ -11,6 +11,7 @@ import io.rodyamirov.brucelang.ast.IfStatementNode;
 import io.rodyamirov.brucelang.ast.IntExprNode;
 import io.rodyamirov.brucelang.ast.ProgramNode;
 import io.rodyamirov.brucelang.ast.ReturnStatementNode;
+import io.rodyamirov.brucelang.ast.StatementListHolder;
 import io.rodyamirov.brucelang.ast.StatementNode;
 import io.rodyamirov.brucelang.ast.StringExprNode;
 import io.rodyamirov.brucelang.ast.UnaryOpExprNode;

--- a/src/main/java/io/rodyamirov/brucelang/staticanalysis/Namespace.java
+++ b/src/main/java/io/rodyamirov/brucelang/staticanalysis/Namespace.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class Namespace {
     private final Namespace parent;
     private final String localName;
+    private final int depth; // 0 for root, parent.depth+1 otherwise
 
     private final Map<String, VariableDeclarationNode> registeredNames = new HashMap<>();
     private final Map<String, Namespace> childSpaces = new HashMap<>();
@@ -24,6 +25,7 @@ public class Namespace {
     private Namespace(@Nonnull Namespace parent, @Nonnull String localName) {
         this.parent = parent;
         this.localName = localName;
+        this.depth = parent.depth + 1;
 
         this.parent.registerChild(localName, this);
     }
@@ -31,6 +33,7 @@ public class Namespace {
     public Namespace(@Nonnull String localName) {
         this.parent = null;
         this.localName = localName;
+        this.depth = 0;
     }
 
     private Namespace makeNamedChild(@Nonnull String localName) {
@@ -44,6 +47,10 @@ public class Namespace {
         }
 
         childSpaces.put(childName, child);
+    }
+
+    public int getDepth() {
+        return depth;
     }
 
     /**

--- a/src/main/java/io/rodyamirov/brucelang/staticanalysis/TreePrinter.java
+++ b/src/main/java/io/rodyamirov/brucelang/staticanalysis/TreePrinter.java
@@ -118,6 +118,8 @@ public class TreePrinter {
 
             indent(blockStatementNode.getNamespace().getDepth());
             stringBuilder.append('}');
+
+            newline();
         }
 
         @Override
@@ -151,6 +153,7 @@ public class TreePrinter {
             stringBuilder.append("if (");
             ifStatementNode.getConditions().get(0).accept(this);
             stringBuilder.append(")");
+            newline();
             ifStatementNode.getResultingStatements().get(0).accept(this);
 
             for (int i = 1; i < ifStatementNode.getConditions().size(); i++) {
@@ -158,12 +161,14 @@ public class TreePrinter {
                 stringBuilder.append(" else if (");
                 ifStatementNode.getConditions().get(i).accept(this);
                 stringBuilder.append(")");
+                newline();
                 ifStatementNode.getResultingStatements().get(i).accept(this);
             }
 
             if (ifStatementNode.getElseStatement() != null) {
                 indent(depth);
                 stringBuilder.append("else");
+                newline();
                 ifStatementNode.getElseStatement().accept(this);
             }
         }

--- a/src/main/java/io/rodyamirov/brucelang/staticanalysis/TreePrinter.java
+++ b/src/main/java/io/rodyamirov/brucelang/staticanalysis/TreePrinter.java
@@ -1,0 +1,216 @@
+package io.rodyamirov.brucelang.staticanalysis;
+
+import io.rodyamirov.brucelang.ast.ASTNode;
+import io.rodyamirov.brucelang.ast.BinOpExprNode;
+import io.rodyamirov.brucelang.ast.BlockStatementNode;
+import io.rodyamirov.brucelang.ast.BoolExprNode;
+import io.rodyamirov.brucelang.ast.DoStatementNode;
+import io.rodyamirov.brucelang.ast.FunctionCallNode;
+import io.rodyamirov.brucelang.ast.FunctionExprNode;
+import io.rodyamirov.brucelang.ast.IfStatementNode;
+import io.rodyamirov.brucelang.ast.IntExprNode;
+import io.rodyamirov.brucelang.ast.ProgramNode;
+import io.rodyamirov.brucelang.ast.ReturnStatementNode;
+import io.rodyamirov.brucelang.ast.StatementNode;
+import io.rodyamirov.brucelang.ast.StringExprNode;
+import io.rodyamirov.brucelang.ast.UnaryOpExprNode;
+import io.rodyamirov.brucelang.ast.VariableDeclarationNode;
+import io.rodyamirov.brucelang.ast.VariableDefinitionNode;
+import io.rodyamirov.brucelang.ast.VariableReferenceNode;
+
+import java.util.List;
+
+public class TreePrinter {
+    private static final String NEW_LINE = System.lineSeparator();
+    private static final int spacesPerTab = 2;
+
+    private TreePrinter() {
+    }
+
+    public static String printTree(ASTNode node) {
+        PrintVisitor printVisitor = new PrintVisitor();
+        node.accept(printVisitor);
+        return printVisitor.stringBuilder.toString();
+    }
+
+    private interface StatementProcessor {
+        void process();
+    }
+
+    private static class PrintVisitor implements ASTNode.ASTVisitor {
+        private final StringBuilder stringBuilder = new StringBuilder();
+
+        private void indent(int scopeDepth) {
+            for (int i = 0; i < scopeDepth * spacesPerTab; i++) {
+                stringBuilder.append(' ');
+            }
+        }
+
+        private void newline() {
+            stringBuilder.append(NEW_LINE);
+        }
+
+        private void simpleStatement(StatementNode node, StatementProcessor processor) {
+            indent(node.getNamespace().getDepth());
+
+            processor.process();
+
+            stringBuilder.append(';');
+            newline();
+        }
+
+        private <T extends ASTNode> void commaSepList(List<T> toVisit) {
+            if (toVisit.size() > 0) {
+                toVisit.get(0).accept(this);
+            }
+
+            for (int i = 1; i < toVisit.size(); i++) {
+                stringBuilder.append(", ");
+                toVisit.get(i).accept(this);
+            }
+        }
+
+        @Override
+        public void visitProgram(ProgramNode programNode) {
+            programNode.getStatements().forEach(node -> node.accept(this));
+        }
+
+        @Override
+        public void visitFunctionExpr(FunctionExprNode functionDefinitionNode) {
+            if (functionDefinitionNode.getParameterNodes().size() == 1) {
+                functionDefinitionNode.getParameterNodes().get(0).accept(this);
+            } else {
+                stringBuilder.append('(');
+                commaSepList(functionDefinitionNode.getParameterNodes());
+                stringBuilder.append(')');
+            }
+
+            stringBuilder.append(" => {");
+            newline();
+            functionDefinitionNode.getDefinitionStatements().forEach(stmt -> stmt.accept(this));
+            stringBuilder.append('}');
+        }
+
+        @Override
+        public void visitVariableDefinition(VariableDefinitionNode variableDefinitionNode) {
+            simpleStatement(
+                    variableDefinitionNode,
+                    () -> {
+                        stringBuilder.append("let ");
+                        variableDefinitionNode.getVariableDeclarationNode().accept(this);
+                        stringBuilder.append(" = ");
+                        variableDefinitionNode.getEvalExpr().accept(this);
+                    }
+            );
+        }
+
+        @Override
+        public void visitVariableDeclaration(VariableDeclarationNode variableDeclarationNode) {
+            stringBuilder.append(variableDeclarationNode.getVarName());
+        }
+
+        @Override
+        public void visitBlockStatement(BlockStatementNode blockStatementNode) {
+            indent(blockStatementNode.getNamespace().getDepth());
+            stringBuilder.append('{');
+
+            blockStatementNode.getStatements().forEach(node -> node.accept(this));
+
+            indent(blockStatementNode.getNamespace().getDepth());
+            stringBuilder.append('}');
+        }
+
+        @Override
+        public void visitDoStatement(DoStatementNode doStatementNode) {
+            simpleStatement(
+                    doStatementNode,
+                    () -> {
+                        stringBuilder.append("do ");
+                        doStatementNode.getEvalExpression().accept(this);
+                    }
+            );
+        }
+
+        @Override
+        public void visitReturnStatement(ReturnStatementNode returnStatementNode) {
+            simpleStatement(
+                    returnStatementNode,
+                    () -> {
+                        stringBuilder.append("return ");
+                        returnStatementNode.getEvalExpression().accept(this);
+                    }
+            );
+        }
+
+        @Override
+        public void visitIfStatement(IfStatementNode ifStatementNode) {
+            int depth = ifStatementNode.getNamespace().getDepth();
+
+            // TODO: this does braces on the next line (gross), fix this later
+            indent(depth);
+            stringBuilder.append("if (");
+            ifStatementNode.getConditions().get(0).accept(this);
+            stringBuilder.append(")");
+            ifStatementNode.getResultingStatements().get(0).accept(this);
+
+            for (int i = 1; i < ifStatementNode.getConditions().size(); i++) {
+                indent(depth);
+                stringBuilder.append(" else if (");
+                ifStatementNode.getConditions().get(i).accept(this);
+                stringBuilder.append(")");
+                ifStatementNode.getResultingStatements().get(i).accept(this);
+            }
+
+            if (ifStatementNode.getElseStatement() != null) {
+                indent(depth);
+                stringBuilder.append("else");
+                ifStatementNode.getElseStatement().accept(this);
+            }
+        }
+
+        @Override
+        public void visitFunctionCallNode(FunctionCallNode functionCallNode) {
+            functionCallNode.getFunctionNode().accept(this);
+            stringBuilder.append('(');
+            commaSepList(functionCallNode.getArguments());
+            stringBuilder.append(')');
+        }
+
+        @Override
+        public void visitBinOpExprNode(BinOpExprNode binOpExprNode) {
+            stringBuilder.append('(');
+            binOpExprNode.getLeftChild().accept(this);
+            stringBuilder.append(binOpExprNode.getOperation().toString());
+            binOpExprNode.getRightChild().accept(this);
+            stringBuilder.append(')');
+        }
+
+        @Override
+        public void visitUnaryOpExprNode(UnaryOpExprNode unaryOpExprNode) {
+            stringBuilder.append('(');
+            stringBuilder.append(unaryOpExprNode.getOperation().toString());
+            unaryOpExprNode.getChild().accept(this);
+            stringBuilder.append(')');
+        }
+
+        @Override
+        public void visitIntExprNode(IntExprNode integerNode) {
+            stringBuilder.append(integerNode.getValue().toString());
+        }
+
+        @Override
+        public void visitBoolExprNode(BoolExprNode booleanNode) {
+            stringBuilder.append(booleanNode.getValue());
+        }
+
+        @Override
+        public void visitStringExprNode(StringExprNode stringExprNode) {
+            stringBuilder.append(stringExprNode.getValue());
+        }
+
+        @Override
+        public void visitVariableReferenceNode(VariableReferenceNode variableReferenceNode) {
+            stringBuilder.append(variableReferenceNode.getVarName());
+        }
+    }
+}

--- a/src/main/java/io/rodyamirov/brucelang/util/collections/Stack.java
+++ b/src/main/java/io/rodyamirov/brucelang/util/collections/Stack.java
@@ -11,8 +11,28 @@ import java.util.EmptyStackException;
  */
 public interface Stack<T> {
     void clear();
+
     void push(T t);
+
     T pop() throws EmptyStackException;
+
+    default T popOr(T defaultValue) {
+        if (this.size() == 0) {
+            return defaultValue;
+        } else {
+            return this.pop();
+        }
+    }
+
     T peek() throws EmptyStackException;
+
+    default T peekOr(T defaultValue) {
+        if (this.size() == 0) {
+            return defaultValue;
+        } else {
+            return this.peek();
+        }
+    }
+
     int size();
 }

--- a/src/main/java/io/rodyamirov/brucelang/util/collections/StackHelper.java
+++ b/src/main/java/io/rodyamirov/brucelang/util/collections/StackHelper.java
@@ -1,0 +1,38 @@
+package io.rodyamirov.brucelang.util.collections;
+
+public class StackHelper<T> {
+    private final Stack<T> stack;
+
+    public StackHelper(Stack<T> stack) {
+        this.stack = stack;
+    }
+
+    /**
+     * Helper method for the familiar pattern of "push something onto the stack, do something, then
+     * pop that value back off the stack," which comes up in ASTVisitors frequently.
+     *
+     * This includes checks at the end to make sure that after the pop, you get the same value back,
+     * and the stack is the same size as it started.
+     */
+    public void safePushPop(T toPush, Procedure toRun) {
+        int startSize = stack.size();
+
+        stack.push(toPush);
+
+        toRun.doSomething();
+
+        T end = stack.pop();
+
+        if (end != toPush) {
+            throw new RuntimeException("Got a different popped value than I pushed in!");
+        } else if (stack.size() != startSize) {
+            String message = String.format(
+                    "Started with size '%d' but ended with size '%d'", startSize, stack.size());
+            throw new RuntimeException(message);
+        }
+    }
+
+    public interface Procedure {
+        void doSomething();
+    }
+}


### PR DESCRIPTION
The program printer is probably useful for whatever. It generates _almost_ valid source code (uses some illegal variable names) which is representative of what it parsed, so it's a good check that parsing is happening correctly without painfully walking through the debugger.

This also desugars anonymous lambda functions (that is, lambda functions which aren't exactly the definition of a variable) by introducing a new variable they are equal to, and using that.

so for instance
```
let x = (a => a+1)(12);
```

will get processed to
```
let $lambda$0 = a => a+1;
let x = $lambda$0(12);
```

this is guaranteed not to affect the semantics of the program (since the lambda can't refer to anything besides names that exist in the previous statement _anyway_).