### PR TITLE
Fixed shadowing prevention, refactor NameRegistry

### DIFF
--- a/samples/TypeDeclarations.bl
+++ b/samples/TypeDeclarations.bl
@@ -1,0 +1,43 @@
+
+let native type String = {
+    length: Fn<Integer>
+}
+
+let native type Integer = {
+    toString: Fn<String>
+}
+
+let type Person = {
+    age: Integer,
+    name: String,
+    friends: List<Person>,
+    friendsNames: Fn<List<String>>
+}
+
+impl Person {
+    define new(age: Integer, name: String) as {
+        this.age = age;
+        this.name = name;
+        this.friends = new List<Person>();
+    }
+
+    define new(age: Integer, name: String, friends: List<Person>) as {
+        this.age = age;
+        this.name = name;
+        this.friends = friends;
+    }
+
+    define friendsNames() as {
+        return this.friends.map(p: Person => p.name);
+    }
+}
+
+let native type List<T> = {
+    get: Fn<Integer, T>,
+    contains: Fn<T, Boolean>,
+    push: Fn<T, None>,
+    pop: Fn<T>,
+    map<T2>: Fn<Fn<T,T2>, List<T2>>,
+    size: Fn<Integer>,
+    clear: Fn<None>
+}

--- a/samples/TypedExample.bl
+++ b/samples/TypedExample.bl
@@ -1,6 +1,7 @@
 define main(): Integer as {
     let x: Integer = 13 + 14;
     let y: Integer = 13 * (x - f(12));
+
     return x - g(y) * chomp(18);
 }
 

--- a/src/main/java/io/rodyamirov/brucelang/Main.java
+++ b/src/main/java/io/rodyamirov/brucelang/Main.java
@@ -37,6 +37,7 @@ public class Main {
         ASTBuilder builder = new ASTBuilder();
         ProgramNode program = builder.visitProgram(parser.program());
         LambdaDesugarer.removeAnonymousFunctions(program);
+
         NameRegistrar.registerNames(program);
         ReturnChecker.checkFunctionsReturn(program);
         TypeWalker.assignAndCheckTypes(program);

--- a/src/main/java/io/rodyamirov/brucelang/staticanalysis/Namespace.java
+++ b/src/main/java/io/rodyamirov/brucelang/staticanalysis/Namespace.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 
 public class Namespace {
     private final Namespace parent;
@@ -81,11 +82,27 @@ public class Namespace {
         }
     }
 
+    private boolean nameIsDefined(String name) {
+        Predicate<Namespace> nameLocallyDefined = namespace ->
+            namespace.registeredNames.containsKey(name);
+
+        Namespace namespace = this;
+
+        while (namespace != null) {
+            if (nameLocallyDefined.test(namespace)) {
+                return true;
+            }
+            namespace = namespace.parent;
+        }
+
+        return false;
+    }
+
     public void register(String name, VariableDeclarationNode definitionNode) {
-        if (registeredNames.containsKey(name)) {
+        if (nameIsDefined(name)) {
             throw new DoubleDefinitionException(
                     definitionNode,
-                    "Name '%s' is already in use in '%s'",
+                    "Name '%s' in '%s' is already in use!",
                     name, this.getFullName()
             );
         }

--- a/src/main/java/io/rodyamirov/brucelang/types/TypeDefinition.java
+++ b/src/main/java/io/rodyamirov/brucelang/types/TypeDefinition.java
@@ -1,0 +1,4 @@
+package io.rodyamirov.brucelang.types;
+
+public class TypeDefinition {
+}

--- a/src/main/java/io/rodyamirov/brucelang/types/TypeRegistrar.java
+++ b/src/main/java/io/rodyamirov/brucelang/types/TypeRegistrar.java
@@ -1,0 +1,4 @@
+package io.rodyamirov.brucelang.types;
+
+public class TypeRegistrar {
+}

--- a/src/main/java/io/rodyamirov/brucelang/util/collections/LinkedQueue.java
+++ b/src/main/java/io/rodyamirov/brucelang/util/collections/LinkedQueue.java
@@ -1,0 +1,19 @@
+package io.rodyamirov.brucelang.util.collections;
+
+import java.util.LinkedList;
+
+public class LinkedQueue<T> extends LinkedList<T> implements Queue<T> {
+    public LinkedQueue() {
+        super();
+    }
+
+    @Override
+    public T dequeue() {
+        return removeFirst();
+    }
+
+    @Override
+    public void enqueue(T t) {
+        add(t);
+    }
+}

--- a/src/main/java/io/rodyamirov/brucelang/util/collections/Queue.java
+++ b/src/main/java/io/rodyamirov/brucelang/util/collections/Queue.java
@@ -1,0 +1,7 @@
+package io.rodyamirov.brucelang.util.collections;
+
+public interface Queue<T> {
+    int size();
+    T dequeue();
+    void enqueue(T t);
+}


### PR DESCRIPTION
Resolves #14 in a desirable way.

impl: Name resolution is now partially on a queue system, rather than a stack; so each namespace's names are completely resolved before going to any of its child spaces.

This assumes (which is true for now) that it is impossible to enter a namespace in more than one way. If that changes we'll have to revisit name registration.